### PR TITLE
Add navbar toggle for mobile

### DIFF
--- a/about.html
+++ b/about.html
@@ -28,6 +28,10 @@
             <a class="navbar-brand heading-black" href="index.html">
                 GG Investments
             </a>
+            <button class="navbar-toggler navbar-toggler-right border-0" type="button" data-toggle="collapse"
+              data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+              <span data-feather="grid"></span>
+            </button>
             <div class="collapse navbar-collapse" id="navbarCollapse">
               <ul class="navbar-nav ml-auto">
                 <li class="nav-item">

--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
             <a class="navbar-brand heading-black" href="index.html">
                 GG Investments
             </a>
+            <button class="navbar-toggler navbar-toggler-right border-0" type="button" data-toggle="collapse"
+              data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+              <span data-feather="grid"></span>
+            </button>
             <div class="collapse navbar-collapse" id="navbarCollapse">
               <ul class="navbar-nav ml-auto">
                 <li class="nav-item">


### PR DESCRIPTION
Add a navbar toggle for mobile, since the About Us page is currently inaccessible via mobile. Icon is provided by the theme.

<img width="488" alt="Screen Shot 2021-09-21 at 11 38 12 PM" src="https://user-images.githubusercontent.com/6720451/134279882-09fcd78d-859c-4b87-a7ba-ddc22a79bc0c.png">
<img width="485" alt="Screen Shot 2021-09-21 at 11 38 20 PM" src="https://user-images.githubusercontent.com/6720451/134279883-1f362a85-dc15-482e-8c78-778057163ddb.png">
Nav link popping up under the logo is meh but it gets the job done.